### PR TITLE
fix: Import subprocess.run

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A python package that lets you sqoop into HDFS/Hive/HBase data from RDBMS using sqoop.
 
 [![PyPI](https://img.shields.io/badge/pip-v.0.0.15-blue.svg)](https://pypi.org/project/pysqoop)
-![Python](https://img.shields.io/badge/python-3.5+,2.7-green.svg)
+![Python](https://img.shields.io/badge/python-3.5+-green.svg)
 [![Tests](https://img.shields.io/badge/tests-6%20%2F%206-brightgreen.svg)](https://github.com/lucafon/pysqoop/blob/master/unittests/unintary_tests.py)
 [![MIT license](http://img.shields.io/badge/license-MIT-orange.svg)](http://opensource.org/licenses/MIT)
 

--- a/pysqoop/pysqoop/SqoopImport.py
+++ b/pysqoop/pysqoop/SqoopImport.py
@@ -1,4 +1,4 @@
-from subprocess import call
+from subprocess import call, run
 import collections
 
 


### PR DESCRIPTION
Upon executing import sqoop function, this is the output after the command gets printed

> name 'run' is not defined

Seems related to e684d03f58815ec02d1ded9d70ddd292caaf97cc

From what I can tell, this is intended to be a `subprocess` import since it was replacing `call` with `run`. 

## Breaking change

This would effectively make this library unavailable for Python < 3.5
