### PR TITLE
fix: Resolve subprocess import error in perform_import() #16

### DIFF
--- a/pysqoop/pysqoop/SqoopImport.py
+++ b/pysqoop/pysqoop/SqoopImport.py
@@ -1,4 +1,5 @@
 from subprocess import call, run
+import subprocess
 import collections
 
 


### PR DESCRIPTION
- Add missing 'import subprocess' to SqoopImport.py
- The perform_import() method uses subprocess.PIPE but only had 'from subprocess import call, run'
- This caused "name 'subprocess' is not defined" NameError when calling perform_import()
- Add comprehensive unit test to verify perform_import() and perform_export() work correctly
- Test ensures methods return proper types (CompletedProcess or int) without NameError

Fixes issue #16 where users encountered subprocess NameError when using sqoop.perform_import()